### PR TITLE
set sys-prop for Arduino devices on Linux

### DIFF
--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Activator.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/Activator.java
@@ -7,6 +7,7 @@ import java.net.UnknownHostException;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
@@ -63,6 +64,13 @@ public class Activator extends AbstractUIPlugin {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		plugin = this;
+
+		// add required properties for Arduino serial port on linux, if not defined
+		if (Platform.getOS().equals(Platform.OS_LINUX) &&
+			System.getProperty(ArduinoConst.ENV_KEY_GNU_SERIAL_PORTS) == null) {
+				System.setProperty(ArduinoConst.ENV_KEY_GNU_SERIAL_PORTS, ArduinoConst.ENV_VALUE_GNU_SERIAL_PORTS_LINUX);
+		}
+		
 		remind();
 		return;
 

--- a/it.baeyens.arduino.common/src/it/baeyens/arduino/common/ArduinoConst.java
+++ b/it.baeyens.arduino.common/src/it/baeyens/arduino/common/ArduinoConst.java
@@ -110,4 +110,6 @@ public class ArduinoConst {
 	public static final String ENV_KEY_WARNING_LEVEL_OFF = "";
 	public static final String ENV_KEY_WARNING_LEVEL_ON = " -Wall ";
 
+	public static final String ENV_KEY_GNU_SERIAL_PORTS = "gnu.io.rxtx.SerialPorts";
+	public static final String ENV_VALUE_GNU_SERIAL_PORTS_LINUX = "/dev/ttyACM0:/dev/ttyACM1:/dev/ttyACM2:/dev/ttyACM3:/dev/ttyUSB0::/dev/ttyUSB1::/dev/ttyUSB2::/dev/ttyUSB3::/dev/ttyUSB4";
 }

--- a/it.baeyens.arduino.core/src/it/baeyens/arduino/tools/ShouldHaveBeenInCDT.java
+++ b/it.baeyens.arduino.core/src/it/baeyens/arduino/tools/ShouldHaveBeenInCDT.java
@@ -13,7 +13,6 @@ import org.eclipse.cdt.managedbuilder.internal.core.Configuration;
 import org.eclipse.cdt.managedbuilder.internal.core.ManagedBuildInfo;
 import org.eclipse.cdt.managedbuilder.internal.core.ManagedProject;
 import org.eclipse.cdt.managedbuilder.internal.core.ToolChain;
-import org.eclipse.cdt.managedbuilder.internal.dataprovider.ConfigurationDataProvider;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;


### PR DESCRIPTION
If the system property gnu.io.rxtx.SerialPorts is not set on linux based
systems, the plug-in automatically sets the following devices to make
serial port work out of the box for serial monitor:
/dev/ttyACM0:/dev/ttyACM1:/dev/ttyACM2:/dev/ttyACM3:/dev/ttyUSB0::/dev/ttyUSB1::/dev/ttyUSB2::/dev/ttyUSB3::/dev/ttyUSB4
