### PR TITLE
Fix #49 -- Nicer error message and behaviour when preferences not set.

### DIFF
--- a/it.baeyens.arduino.core/src/it/baeyens/arduino/tools/ArduinoHelpers.java
+++ b/it.baeyens.arduino.core/src/it/baeyens/arduino/tools/ArduinoHelpers.java
@@ -368,7 +368,7 @@ public class ArduinoHelpers extends Common {
 	if (depth > 0) {
 	    File[] a = folder.listFiles();
 	    if (a == null) {
-		Common.log(new Status(IStatus.ERROR, ArduinoConst.CORE_PLUGIN_ID, "the folder " + folder + "does not contain any files.", null));
+		Common.log(new Status(IStatus.ERROR, ArduinoConst.CORE_PLUGIN_ID, "The folder " + folder + " does not contain any files.", null));
 		return;
 	    }
 	    for (File f : a) {

--- a/it.baeyens.arduino.core/src/it/baeyens/arduino/ui/ArduinoSettingsPage.java
+++ b/it.baeyens.arduino.core/src/it/baeyens/arduino/ui/ArduinoSettingsPage.java
@@ -1,6 +1,12 @@
 package it.baeyens.arduino.ui;
 
+import it.baeyens.arduino.common.ArduinoConst;
+import it.baeyens.arduino.common.ArduinoInstancePreferences;
+import it.baeyens.arduino.common.Common;
+
 import org.eclipse.cdt.core.settings.model.ICConfigurationDescription;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardPage;

--- a/it.baeyens.arduino.core/src/it/baeyens/arduino/ui/NewArduinoSketchWizard.java
+++ b/it.baeyens.arduino.core/src/it/baeyens/arduino/ui/NewArduinoSketchWizard.java
@@ -65,27 +65,37 @@ public class NewArduinoSketchWizard extends Wizard implements INewWizard, IExecu
     private IProject mProject;
 
     public NewArduinoSketchWizard() {
-	super();
+        super();
     }
 
-    @Override
-    public void addPages() {
-	mWizardPage = new WizardNewProjectCreationPage("New Arduino sketch");
-	mWizardPage.setDescription("Create a new Arduino sketch.");
-	mWizardPage.setTitle("New Arduino sketch");
+	@Override
+	public void addPages() {
+		//Check if preferences of Arduino IDE path is set/exists.
+		if ( ArduinoInstancePreferences.getArduinoPath().toFile().exists() ) {
+		    //Everything is OK and we want to display the pages
+			mWizardPage = new WizardNewProjectCreationPage("New Arduino sketch");
+			mWizardPage.setDescription("Create a new Arduino sketch.");
+			mWizardPage.setTitle("New Arduino sketch");
 
-	mArduinoPage = new ArduinoSettingsPage("Arduino information");
-	mArduinoPage.setTitle("Provide the Arduino information.");
-	mArduinoPage.setDescription("These settings can be changed later.");
+			mArduinoPage = new ArduinoSettingsPage("Arduino information");
+			mArduinoPage.setTitle("Provide the Arduino information.");
+			mArduinoPage.setDescription("These settings can be changed later.");
 
-	mBuildCfgPage = new BuildConfigurationsPage("Build configurations");
-	mBuildCfgPage.setTitle("Select additional build configurations for this project.");
-	mBuildCfgPage.setDescription("If you are using additional tools you may want one or more of these extra configurations.");
-	
-	addPage(mWizardPage);
-	addPage(mArduinoPage);
-	addPage(mBuildCfgPage);
-    }
+			mBuildCfgPage = new BuildConfigurationsPage("Build configurations");
+			mBuildCfgPage.setTitle("Select additional build configurations for this project.");
+			mBuildCfgPage.setDescription("If you are using additional tools you may want one or more of these extra configurations.");
+
+			addPage(mWizardPage);
+			addPage(mArduinoPage);
+			addPage(mBuildCfgPage);
+		}else{
+
+			//If not then we bail out with an error.
+			//And no pages are presented (with no option to FINISH).
+			Common.log(new Status(IStatus.ERROR, ArduinoConst.CORE_PLUGIN_ID, "Arduino IDE path does not exist. Check Window>Preferences>Arduino", null));
+			return;
+		}
+	}
 
     @Override
     public boolean performFinish() {


### PR DESCRIPTION
If Arduino IDE pref is not set then we give a better error of "Arduino
IDE path does not exist. Check Window>Preferences>Arduino"

and don't let any further progress through the pages.
