### PR TITLE
Set CDT perspective at startup.

### DIFF
--- a/it.baeyens.arduino.product/plugin_customization.ini
+++ b/it.baeyens.arduino.product/plugin_customization.ini
@@ -1,1 +1,2 @@
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = true
+org.eclipse.ui/defaultPerspectiveId=org.eclipse.cdt.ui.CPerspective


### PR DESCRIPTION
Fixes issue #108 setting CDT perspective by default.
