### PR TITLE
 	#170 Make a "New Sketch" shortcut in the context menu of the project explorer

### DIFF
--- a/it.baeyens.arduino.core/META-INF/MANIFEST.MF
+++ b/it.baeyens.arduino.core/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.filesystem,
  org.eclipse.ui.ide,
  org.eclipse.cdt.core,
- org.eclipse.equinox.security;bundle-version="1.1.100"
+ org.eclipse.equinox.security;bundle-version="1.1.100",
+ org.eclipse.ui.navigator
 Bundle-Vendor: Jan Baeyens
 Bundle-ActivationPolicy: lazy
 Export-Package: it.baeyens.arduino.tools,

--- a/it.baeyens.arduino.core/plugin.xml
+++ b/it.baeyens.arduino.core/plugin.xml
@@ -103,7 +103,7 @@
 			category="it.baeyens.arduino.eclipse.newWizards"
 	        class="it.baeyens.arduino.ui.NewArduinoSketchWizard"
 	        name="%wizard.name"
-	        icon="icons/arduino.png"
+	        icon="icons/new.png"
 	        finalPerspective ="it.baeyens.arduino.application.perspective"
 	        project="true">
          <description>
@@ -786,6 +786,23 @@
              id="it.baeyens.arduino.eclipse.NewArduinoSketchWizard">
        </newWizardShortcut>
     </perspectiveExtension>
+ </extension>
+ <extension
+       point="org.eclipse.ui.navigator.navigatorContent">
+    <commonWizard
+          type="new"
+          wizardId="it.baeyens.arduino.eclipse.NewArduinoSketchWizard">
+       <enablement>
+          <or>
+             <adapt
+                   type="org.eclipse.core.resources.IProject">
+             </adapt>
+             <adapt
+                   type="org.eclipse.core.resources.IWorkspaceRoot">
+             </adapt>
+          </or>
+       </enablement>
+    </commonWizard>
  </extension>
 
 


### PR DESCRIPTION
New sketch will not be shown in empty project explorer
Top level new menu is populated with "New Sketch"
After a project is created the "New Sketch" wizard is available from the project explorer context menu.
Changed huge icon of the wizard into the one displayed on the toolbar
