### PR TITLE
Link to new files

### DIFF
--- a/website/WebContent/fragments/files.php
+++ b/website/WebContent/fragments/files.php
@@ -4,26 +4,30 @@
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V2.2/V2.2_linux64.2014-01-19_15-16-30.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V2.2/V2.2_mac64.2014-01-19_15-16-30.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V2.2/V2.2_win64.2014-01-19_15-16-30.tar.gz",
+
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V2.4/V2.4_linux32.2015-12-06_20-24-02.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V2.4/V2.4_linux64.2015-12-06_20-24-02.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V2.4/V2.4_mac64.2015-12-06_20-24-02.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V2.4/V2.4_win32.2015-12-06_20-24-02.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V2.4/V2.4_win64.2015-12-06_20-24-02.tar.gz",
+
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.0/V3.0_linux32.2016-03-31_23-40-46.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.0/V3.0_linux64.2016-03-31_23-40-46.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.0/V3.0_mac64.2016-03-31_23-40-46.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.0/V3.0_win32.2016-03-31_23-40-46.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.0/V3.0_win64.2016-03-31_12-43-53.tar.gz",
+
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.1/V3.1_linux32.2016-08-03_16-31-05.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.1/V3.1_linux64.2016-08-03_16-31-05.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.1/V3.1_mac64.2016-08-03_16-31-05.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.1/V3.1_win32.2016-08-03_16-31-05.tar.gz",
 	"https://github.com/jantje/arduino-eclipse-plugin/releases/download/V3.1/V3.1_win64.2016-08-03_16-31-05.tar.gz",
-	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_linux32.2017-01-16_22-27-00.tar.gz",
-	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_linux64.2017-01-16_22-27-00.tar.gz",
-	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_mac64.2017-01-16_22-27-00.tar.gz",
-	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_win32.2017-01-16_22-27-00.tar.gz",
-	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_win64.2017-01-16_22-27-00.tar.gz"
+
+	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_linux32.2017-01-17_15-14-48.tar.gz",
+	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_linux64.2017-01-17_15-14-48.tar.gz",
+	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_mac64.2017-01-17_15-14-48.tar.gz",
+	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_win32.2017-01-17_15-14-48.tar.gz",
+	"https://github.com/Sloeber/arduino-eclipse-plugin/releases/download/V4.0/V4.0_win64.2017-01-17_15-14-48.tar.gz"
 	);
 
 ?>


### PR DESCRIPTION
Due to the baeyens.it to sloeber.io and the clean that didn't work I think 3.1 was in the 4.0 files.
I reuploaded the files so now the listing needs to be updated on the web site.
I did so directly on the server but this is a coipy so when the github content is pushed the links still work.