### PR TITLE
First part of autodetecting new com port

### DIFF
--- a/io.sloeber.core/src/io/sloeber/core/api/BoardDescriptor.java
+++ b/io.sloeber.core/src/io/sloeber/core/api/BoardDescriptor.java
@@ -3,6 +3,7 @@ package io.sloeber.core.api;
 import java.io.File;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -918,6 +919,25 @@ public class BoardDescriptor {
 		}
 		String ret = Common.getBuildEnvironmentVariable(confdesc,
 				"A.TOOLS." + upLoadTool.toUpperCase() + "." + action + ".PATTERN", "");
+		
+		// Below we handle the case where the port might have moved. This should be reasonably safe,
+		// since the port value that we have has to have been set, and it has to match a value from
+		// the port list ignoring any numbers on the end. If this specific scenario doesn't occur,
+		// then it will have no effect.
+		String oldComPort = getUploadPort();
+		if (!"".equals(oldComPort)) {
+			String[] comPorts = SerialManager.listComPorts();
+			List<String> ports = Arrays.asList(comPorts);
+			if (!ports.contains(oldComPort)) {
+				for (String port: ports) {
+					if (port.replaceAll("\\d+$", "").equals(oldComPort.replaceAll("\\d+$", ""))) {
+						setUploadPort(port);
+						ret = ret.replace(oldComPort, port);
+					}
+				}
+			}			
+		}
+		
 		if (ret.isEmpty()) {
 			Common.log(new Status(IStatus.ERROR, Const.CORE_PLUGIN_ID, "tools." + upLoadTool + "."
 					+ action.toLowerCase() + ".pattern : not found in the platform.txt file"));


### PR DESCRIPTION
Just for concept review at the moment.  It's a bit hackish, because we have a template at project preference save time but all the values get populated in the template at save time.  But I think the concept is reasonable.  It should be safe from interfering with other types of ports (i.e. remote uploads, etc, where you would not have a port value that would resemble a port retrieved from the serial port list).

I was planning to make it an optional thing, which I have not yet implemented.  Also, it does not reset the proper serial monitor yet.

Would appreciate feedback as to whether this approach makes sense to you.