### PR TITLE
adds eclipse settings to ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /log.txt
 workspace/*
 /.metadata/
+.settings


### PR DESCRIPTION
the `.project` files and the `.settings` folders should never get into the repository as they contain values specific to the local dev environment (sometimes also things you want to keep secret). Also, those files should be rebuilt by Eclipse upon importing the maven modules, so they can be considered _generated_ files.