### PR TITLE
Build with Java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'adopt'
     - name: Build with Maven
       run: mvn --no-transfer-progress verify -Pall,sloeber_release,NOSDK -Dtest=NightlyJenkins -DfailIfNoTests=false 


### PR DESCRIPTION
The nls1 requires java 17 but the compile uses Java 11. This updates the compile to Java 17. Alternatively, the nls bundle may be downgraded to Java 11