### PR TITLE
Move to fixed nebula

### DIFF
--- a/io.sloeber.parent/pom.xml
+++ b/io.sloeber.parent/pom.xml
@@ -351,7 +351,7 @@
 		<repository>
 			<id>nebula</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/nebula/releases/latest/</url>
+			<url>https://download.eclipse.org/nebula/releases/2.7.2/</url>
 		</repository>
 
 		<repository>

--- a/io.sloeber.product.sdk/arduino.product
+++ b/io.sloeber.product.sdk/arduino.product
@@ -280,13 +280,12 @@ United States, other countries, or both.
    </configurations>
 
    <repositories>
-      <repository location="http://download.eclipse.org/nebula/releases/latest/" enabled="true" />
-      <repository location="http://eclipse.baeyens.it/update/V4/nightly/" enabled="false" />
-      <repository location="http://eclipse.baeyens.it/update/V4/stable/" enabled="true" />
-      <repository location="http://gnu-mcu-eclipse.netlify.com/v4-neon-updates/" enabled="true" />
-      <repository location="http://download.eclipse.org/releases/latest/" enabled="true" />
-      <repository location="https://download.eclipse.org/technology/babel/update-site/latest/" enabled="true" />
-      <repository location="http://https://download.eclipse.org/justj/jres/15/updates/release/latest/" enabled="true" />
+      <repository location="https://eclipse.baeyens.it/update/V4/nightly/" enabled="false" />
+      <repository location="https://eclipse.baeyens.it/update/V4/stable/" enabled="true" />
+      <repository location="https://download.eclipse.org/technology/babel/update-site/latest/" enabled="false" />
+      <repository location="https://download.eclipse.org/nebula/releases/2.7.2/" enabled="true" />
+      <repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest/" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/latest/" enabled="true" />
       <repository location="https://download.eclipse.org/eclipse/updates/latest" enabled="true" />
    </repositories>
 

--- a/io.sloeber.product/arduino.product
+++ b/io.sloeber.product/arduino.product
@@ -267,6 +267,8 @@ United States, other countries, or both.
       <repository location="https://download.eclipse.org/technology/babel/update-site/latest/" enabled="false" />
       <repository location="https://download.eclipse.org/nebula/releases/2.7.2/" enabled="true" />
       <repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest/" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/latest/" enabled="true" />
+      <repository location="https://download.eclipse.org/eclipse/updates/latest" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/io.sloeber.product/arduino.product
+++ b/io.sloeber.product/arduino.product
@@ -265,7 +265,7 @@ United States, other countries, or both.
       <repository location="https://eclipse.baeyens.it/update/V4/nightly/" enabled="false" />
       <repository location="https://eclipse.baeyens.it/update/V4/stable/" enabled="true" />
       <repository location="https://download.eclipse.org/technology/babel/update-site/latest/" enabled="false" />
-      <repository location="https://download.eclipse.org/nebula/releases/latest/" enabled="true" />
+      <repository location="https://download.eclipse.org/nebula/releases/2.7.2/" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/io.sloeber.product/arduino.product
+++ b/io.sloeber.product/arduino.product
@@ -266,6 +266,7 @@ United States, other countries, or both.
       <repository location="https://eclipse.baeyens.it/update/V4/stable/" enabled="true" />
       <repository location="https://download.eclipse.org/technology/babel/update-site/latest/" enabled="false" />
       <repository location="https://download.eclipse.org/nebula/releases/2.7.2/" enabled="true" />
+      <repository location="https://download.eclipse.org/justj/jres/17/updates/release/latest/" enabled="true" />
    </repositories>
 
    <preferencesInfo>

--- a/io.sloeber.product/sloeber.target
+++ b/io.sloeber.product/sloeber.target
@@ -10,7 +10,7 @@
 			<unit id="org.apache.commons.lang" version="2.6.0.v20220406-2305"/>
 		</location>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/nebula/releases/latest/"/>
+			<repository location="https://download.eclipse.org/nebula/releases/2.7.2/"/>
 			<unit id="org.eclipse.nebula.widgets.oscilloscope.css.feature.feature.group" version="0.0.0"/>
 			<unit id="org.eclipse.nebula.widgets.oscilloscope.feature.feature.group" version="0.0.0"/>
 		</location>

--- a/io.sloeber.updatesite/category.xml
+++ b/io.sloeber.updatesite/category.xml
@@ -20,7 +20,7 @@
    <repository-reference location="https://download.eclipse.org/eclipse/updates/latest" enabled="true" />
    <repository-reference location="https://download.eclipse.org/technology/babel/update-site/latest/" enabled="true" />
    <repository-reference location="https://download.eclipse.org/justj/jres/17/updates/release/latest/" enabled="true" />
-   <repository-reference location="https://download.eclipse.org/nebula/snapshot/" enabled="true" />
+   <repository-reference location="https://download.eclipse.org/nebula/releases/2.7.2/" enabled="true" />
    <repository-reference location="https://eclipse.baeyens.it/update/V4/stable/" enabled="false" />
    <repository-reference location="https://eclipse.baeyens.it/update/V4/nightly/" enabled="true" />
 </site>


### PR DESCRIPTION
The repositories sometimes refer to snapshots and sometimes to the latest. To avoid nebula problems as we saw, I propose moving to a fixed nebula repository release 2.7.2.

I also resolved other potential problems in this area.