### PR TITLE
Various fixes

### DIFF
--- a/build_then_launch.sh
+++ b/build_then_launch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-file_x86="./io.sloeber.product/target/products/io.sloeber.product/linux/gtk/x86/sloeber/sloeber-ide"
-file_x86_64="./io.sloeber.product/target/products/io.sloeber.product/linux/gtk/x86_64/sloeber/sloeber-ide"
+file_x86="./io.sloeber.product/target/products/io.sloeber.product/linux/gtk/x86/Sloeber/sloeber-ide"
+file_x86_64="./io.sloeber.product/target/products/io.sloeber.product/linux/gtk/x86_64/Sloeber/sloeber-ide"
 file=""
 
 echo "Trying to build and then launch the Arduino Eclipse IDE"

--- a/build_then_launch.sh
+++ b/build_then_launch.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-file_x86="./io.sloeber.product/target/products/io.sloeber.product/linux/gtk/x86/Sloeber/sloeber-ide"
 file_x86_64="./io.sloeber.product/target/products/io.sloeber.product/linux/gtk/x86_64/Sloeber/sloeber-ide"
 file=""
 
@@ -23,11 +22,6 @@ fi
 
 echo "Searching for the Eclipse executable (with our plugin pre-packaged) to launch"
 #Find an executable if we made it successfully
-if [[ -x "$file_x86" ]]
-then
-    #echo "File '$file_x86' is executable"
-    file=$file_x86
-fi
 
 if [[ -x "$file_x86_64" ]]
 then

--- a/io.sloeber.product/pom.xml
+++ b/io.sloeber.product/pom.xml
@@ -34,7 +34,7 @@
 				<configuration>
 					<formats>
 						<win32>zip</win32>
-						<linux>zip</linux>
+						<linux>tar.gz</linux>
 						<macosx>zip</macosx>
 					</formats>
 					<products>

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,8 @@ You only need to do one.
 ## Prerequisites
 Please install [git](http://git-scm.com/downloads) and [maven](http://maven.apache.org/download.cgi).
 
+Java 17 is required.
+
 ## Build from the command line from source for your os and the default eclipse instance
 ```bash
 git clone https://github.com/Sloeber/arduino-eclipse-plugin sloeber
@@ -50,14 +52,23 @@ You can control the maven build with the following profiles:
 * macm1
 
 ### Examples
-    mvn clean verify -Pwin64,latest,NOSDK -DskipTests=true (builds for latest eclipse and windows bits)
-    mvn clean verify -Plinux32,latest.NOSDK -DskipTests=true (builds for latest eclipse and linux 32 bits)
-    mvn clean verify -PSDK,win64,latest -DskipTests=true (builds the Sloeber SDK. For Sloeber programmers.)
+
+* Build the latest version for the platform you are running on:
+
+    `mvn clean verify -DskipTests=true`
+
+* Build Eclipse + Sloeber for 64-bit Windows:
+    `mvn clean verify -Pwin64,latest,NOSDK -DskipTests=true`
+		
+* Build Eclipse + Sloeber for 64-bit Linux:
+    `mvn clean verify -Plinux64,latest,NOSDK -DskipTests=true`
+		
+* Build Eclipse + Sloeber for 32-bit Linux:
+    `mvn clean verify -Plinux32,latest,NOSDK -DskipTests=true`
+		
+* Build the Sloeber SDK (for Sloeber programmers):
+    `mvn clean verify -PSDK,win64,latest -DskipTests=true`
     
-To build for latest and the platform you are running on:
-
-    mvn clean verify -DskipTests=true
-
 # Importing your build into another Eclipse
 If you want to import the latest code based plugin to another Eclipse setup you have then it is possible to setup a local repository to install the plugin you have just built. Just add a local repository with location ```arduino-eclipse-plugin/io.sloeber.product/target/repository```
 

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,9 @@ Please install [git](http://git-scm.com/downloads) and [maven](http://maven.apac
 
 Java 17 is required.
 
+A 64-bit OS is required.
+
+
 ## Build from the command line from source for your os and the default eclipse instance
 ```bash
 git clone https://github.com/Sloeber/arduino-eclipse-plugin sloeber
@@ -45,7 +48,6 @@ You can control the maven build with the following profiles:
 
 * latest (default, builds against the latest versions)
 * SDK (builds a Sloeber you can program Sloeber in. With Java.)
-* win32 (builds for 32 bit windows)
 * win64
 * linux64
 * mac64
@@ -55,7 +57,7 @@ You can control the maven build with the following profiles:
 
 * Build the latest version for the platform you are running on:
 
-    `mvn clean verify -DskipTests=true`
+    `mvn clean verify -PNOSDK -DskipTests=true`
 
 * Build Eclipse + Sloeber for 64-bit Windows:
     `mvn clean verify -Pwin64,latest,NOSDK -DskipTests=true`
@@ -63,10 +65,7 @@ You can control the maven build with the following profiles:
 * Build Eclipse + Sloeber for 64-bit Linux:
     `mvn clean verify -Plinux64,latest,NOSDK -DskipTests=true`
 		
-* Build Eclipse + Sloeber for 32-bit Linux:
-    `mvn clean verify -Plinux32,latest,NOSDK -DskipTests=true`
-		
-* Build the Sloeber SDK (for Sloeber programmers):
+* Build the Sloeber SDK for 64-bit Windows (for Sloeber programmers):
     `mvn clean verify -PSDK,win64,latest -DskipTests=true`
     
 # Importing your build into another Eclipse


### PR DESCRIPTION
* Changed Linux package format to `tar.gz`
    Fixes [issue 1577](https://github.com/Sloeber/arduino-eclipse-plugin/issues/1577)
    Fixes [issue 1557](https://github.com/Sloeber/arduino-eclipse-plugin/issues/1557)
    When using `tar.gz` instead of `zip` the Linux file permissions are preserved (i.e. `sloeber-ide`, `jexec`, and `jspawnhelper` are all executable).
    **The download page at [http://eclipse.baeyens.it/stable.php?OS=Linux](http://eclipse.baeyens.it/stable.php?OS=Linux) also needs to be updated with the new filename.**  The text saying to run `chmod` can be removed.
* Fixed executable paths in `build_then_launch.sh` (paths are case-sensitive on Linux *et al.*)
* Added note about requiring Java 17 to top-level `readme.md`
   This fixes [issue 1544](https://github.com/Sloeber/arduino-eclipse-plugin/issues/1544)
* Cleaned-up and corrected examples in top-level `readme.md`
   Several of the examples had `latest.NOSDK` (with a period) instead of `latest,NOSDK` (with a comma).